### PR TITLE
add REPOSTS to ev.kind enum

### DIFF
--- a/pynostr/event.py
+++ b/pynostr/event.py
@@ -20,6 +20,7 @@ class EventKind(IntEnum):
     CONTACTS = 3
     ENCRYPTED_DIRECT_MESSAGE = 4
     DELETE = 5
+    REPOSTS = 6
     REACTION = 7
     BADGE_AWARD = 8
     CHANNEL_CREATE = 40


### PR DESCRIPTION
I'm experimenting with the pynostr library 
and REPOST (Event Kinds) is also useful - EventKind(IntEnum)

NIP18: REPOSTS is Kind 6
https://github.com/nostr-protocol/nips/blob/master/18.md

add this little addition please
hopefully I'll be able to do another expansion as well

