### PR TITLE
fix EventMessage event attribute to type Event

### DIFF
--- a/pynostr/message_pool.py
+++ b/pynostr/message_pool.py
@@ -12,7 +12,7 @@ from .message_type import RelayMessageType
 
 @dataclass
 class EventMessage:
-    event: str
+    event: Event
     subscription_id: str
     url: str
 


### PR DESCRIPTION
when getting messages from the message pool, `EventMessage`s have an attribute called `event` that has the type of `str`. however when looking at the message processing loop, the event json is parsed and [put into an Event class](https://github.com/holgern/pynostr/blob/e5dfe909249321b39d64f5a4ed7b37fab6ba682b/pynostr/message_pool.py#L127) and later put on the `EventMessage` as the event attribute. this PR just updates the types to be correct to improve the developer experience.