### PR TITLE
Fixed NotRenderableError in table rows

### DIFF
--- a/examples/show_metadata.py
+++ b/examples/show_metadata.py
@@ -88,12 +88,13 @@ if __name__ == "__main__":
     newest_metadata = relay_list2[-1][1]["metadata"]
     table = Table("key", "value")
     for key, value in newest_metadata.metadata_to_dict().items():
-        table.add_row(key, value)
+        table.add_row(str(key), str(value))  # Convert key and value to string
     console.print(table)
 
     if len(newest_metadata.identities) > 0:
         table = Table("claim_type", "identity", "proof")
         for identity in newest_metadata.identities:
-            table.add_row(identity.claim_type, identity.identity, identity.proof)
+            table.add_row(str(identity.claim_type), str(identity.identity), str(identity.proof))  # Convert all to string
 
         console.print(table)
+


### PR DESCRIPTION
### Overview
This pull request addresses a bug in the script where `NotRenderableError` is thrown when attempting to add integer values to rows in a Rich table. The Rich library requires all objects added to a table to be renderable, usually as strings. However, in the current implementation, integers (and possibly other non-string types) are directly added to the table, causing an error.

### Bug Description
When executing the script, an error is thrown in the section where the script tries to add rows to a Rich table with integer values. Specifically, the error is a `rich.errors.NotRenderableError`, indicating that an integer (or a non-renderable type) is being added to the table.

### Changes Made
- I modified the script to ensure all values added to the Rich table are converted to strings. This conversion is done before they are passed to the `add_row` method of the `Table` class.
- Key sections where changes were made include the parts of the script adding metadata key-value pairs and identity information to the table. 
- Each value, whether it's a key, a value from the metadata, or identity information, is explicitly converted to a string using `str()`.

### Impact
- These changes will prevent the `NotRenderableError` and ensure that the script runs smoothly without crashing when adding data to Rich tables.
- This fix enhances the script's robustness, especially when dealing with various data types that need to be displayed in table format.

### Additional Notes
- All changes have been tested to ensure that they resolve the issue without introducing any new bugs.

I look forward to any feedback or further suggestions for improvement on this fix.
